### PR TITLE
Do not reset selected items, but fetch them again

### DIFF
--- a/resources/views/forms/components/belongs-to-many-input.blade.php
+++ b/resources/views/forms/components/belongs-to-many-input.blade.php
@@ -19,10 +19,9 @@
 
                 this.loading = false
             })
-            
+
             $wire.$on('belongs-to-many::resetSelected-{{ $getStatePath() }}', () => {
-                this.selected = []
-                this.loading = false
+                $wire.dispatchFormEvent('belongs-to-many::fetchItems', '{{ $getStatePath() }}')
             })
 
             $watch('search', () => this.page = 1)


### PR DESCRIPTION
Issue was that with the previous code we would clear the selected items, but now we will refetch them. So they do not get cleared on the edit page.